### PR TITLE
README: Document W3C TC is unsupported for tracing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ WebApplicationInfo wsInfo = oneAgentSdk.createWebApplicationInfo("WebShopProduct
 ```
 
 To trace a specific incoming web request you then need to create a Tracer object. Make sure you provide all http headers from the request to the SDK by
-calling addRequestHeader(...). This ensures that tagging with our built-in sensor will work, but note that only the X-dynaTrace header
+calling addRequestHeader(...). This ensures that tagging with our built-in sensor will work, but note that only the proprietary x-dynatrace header
 will be processed (meaning, W3C trace context is not supported for tracing with the OneAgent SDKs, use OpenTelemetry instead if you require this).
 
 ```Java

--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ WebApplicationInfo wsInfo = oneAgentSdk.createWebApplicationInfo("WebShopProduct
 ```
 
 To trace a specific incoming web request you then need to create a Tracer object. Make sure you provide all http headers from the request to the SDK by
-calling addRequestHeader(...). This ensures that tagging with our built-in sensor will work.
+calling addRequestHeader(...). This ensures that tagging with our built-in sensor will work, but note that only the X-dynaTrace header
+will be processed (meaning, W3C trace context is not supported for tracing with the OneAgent SDKs, use OpenTelemetry instead if you require this).
 
 ```Java
 IncomingWebRequestTracer tracer = oneAgentSdk.traceIncomingWebRequest(wsInfo,"https://www.oursupershop.com/api/service/checkout/save", "POST")


### PR DESCRIPTION
This clarifies the current status quo as the documentation became quite misleading with the advent of W3C trace context support in the rest of Dynatrace.